### PR TITLE
ADD support to dump memreserve entries from the DT table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,14 @@ impl<'i, 'dt> FdtDumper {
         self.dump
             .push_str(format!("// size_dt_struct:\t{:#x}\n", fdt.size_dt_struct()).as_str());
         self.dump.push('\n');
+
+        for rsv in fdt.reserved_entries() {
+            self.dump
+            .push_str(format!("/memreserve/ {:#x} {:#x};\n", u64::from(rsv.address), u64::from(rsv.size)).as_str());
+        }
+
+        self.dump.push('\n');
+
     }
 
     pub(crate) fn dump_tree(buf: &[u8]) -> DevTreeResult<()> {


### PR DESCRIPTION
This table is outside the tree and is pointed to by off_mem_rsvmap in the FDT header.

The produced text is modeled after fdtdump.